### PR TITLE
Fix breaking json error

### DIFF
--- a/json.c
+++ b/json.c
@@ -161,7 +161,7 @@ int json_printfile(char *dirname, char *filename, struct _info *file, int descen
 
 int json_error(char *error)
 {
-  fprintf(outfile,"{\"error\": \"%s\"}%s",error, noindent?"":"\n");
+  fprintf(outfile,",%s{\"error\": \"%s\"}", noindent?"":"\n", error);
   return 0;
 }
 

--- a/tree.c
+++ b/tree.c
@@ -613,7 +613,7 @@ void usage(int n)
 	"  --info        Print information about files found in .info files.\n"
 	"  --noreport    Turn off file/directory count at end of tree listing.\n"
 	"  --charset X   Use charset X for terminal/HTML and indentation line output.\n"
-	"  --filelimit # Do not descend dirs with more than # files in them.\n"
+	"  --filelimit # Do not descend dirs with more than # files/folders in them.\n"
 	"  -o filename   Output to file instead of stdout.\n"
 	"  ------- File options -------\n"
 	"  -q            Print non-printable characters as '?'.\n"


### PR DESCRIPTION
Errors in JSON representation of the tree break without a starting comma.

Right now, it creates an additional object which is not ideal, the comma just prevents it breaking. I tried fixing it properly but I don't actually know the C language. I was mostly guessing.

The original intention was this, which would be much better.
https://github.com/Old-Man-Programmer/tree/blob/77ebb0aa85854ff419891c008d82c9a74a382581/json.c#L38
