### PR TITLE
Add OSC 8 hyperlinks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ DESTDIR=${PREFIX}/bin
 MAN=tree.1
 # Probably needs to be ${PREFIX}/share/man for most systems now
 MANDIR=${PREFIX}/man
-OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o
+OBJS=tree.o list.o hash.o color.o file.o filter.o info.o unix.o xml.o json.o html.o strverscmp.o osc8.o
 
 # Uncomment options below for your particular OS:
 

--- a/doc/tree.1
+++ b/doc/tree.1
@@ -35,6 +35,7 @@ tree \- list contents of directories in a tree-like format.
 [\fB--metafirst\fP]
 [\fB--ignore-case\fP]
 [\fB--nolinks\fP]
+[\fB--hyperlink\fP]
 [\fB--hintro\fP[\fB=\fP]\fIfile\fP]
 [\fB--houtro\fP[\fB=\fP]\fIfile\fP]
 [\fB--inodes\fP]
@@ -339,6 +340,11 @@ Turn colorization on always, using built-in color defaults if the LS_COLORS or
 TREE_COLORS environment variables are not set.  Useful to colorize output to a
 pipe.
 .PP
+.TP
+.B --hyperlink
+Turn OSC 8 hyperlinks on. This will emit an Operating System Command 8 sequence for 
+each filename. This creates a hyperlink that the terminal emulator is than able to expose
+to the user to interact with.
 
 .SH XML/JSON/HTML OPTIONS
 
@@ -452,6 +458,8 @@ share the same comment.
 \fBTREE_COLORS\fP	Uses this for color information over LS_COLORS if it is set.
 .br
 \fBTREE_CHARSET\fP	Character set for tree to use in HTML mode.
+.br
+\fBTREE_OSC8_HOST\fP	Enables OSC 8 hyperlinks and set the hostname to the variables's value.
 .br
 \fBCLICOLOR\fP		Enables colorization even if TREE_COLORS or LS_COLORS is not set.
 .br

--- a/osc8.c
+++ b/osc8.c
@@ -1,0 +1,65 @@
+#include "tree.h"
+
+extern bool hyperlinkflag;
+char *hyperlinkHostname = NULL;
+extern FILE *outfile;
+bool osc8_enabled=FALSE;
+
+// This function is from html.c
+void url_encode(FILE *fd, char *s);
+
+int print_osc8(const char* dirname, char* filename)
+{
+  int len = 0;
+  char fullpath[PATH_MAX];
+  char* path=NULL;
+
+  // For the root, there is no dirname given
+  if (dirname != NULL)
+    len += strlen(dirname) + 1; // +1 for /
+  len += strlen(filename) + 1; // +1 for \0
+  path = calloc(len, sizeof(char));
+
+  if (dirname != NULL)
+    snprintf(path, len, "%s/%s", dirname, filename);
+  else
+    snprintf(path, len, "%s", filename);
+
+  if (realpath(path, fullpath) == NULL) {
+    perror("tree: Error executing realpath");
+    return 1;
+  }
+
+  fprintf(outfile, "\033]8;;file://%s", hyperlinkHostname);
+  url_encode(outfile, fullpath);
+  fprintf(outfile, "\033\\");
+
+  free(path);
+  return 0;
+}
+
+void endosc8() 
+{
+  fprintf(outfile, "\033]8;;\033\\");
+}
+
+void osc8_setup()
+{
+  hyperlinkHostname = getenv("TREE_OSC8_HOST");
+  if (hyperlinkHostname != NULL){
+    osc8_enabled=TRUE;
+  }
+  else if (hyperlinkflag) {
+    int maxHostLength = 256;
+    char hostname[maxHostLength];
+    memset(hostname, 0, maxHostLength);
+    if (gethostname(hostname, maxHostLength) < 0) {
+      fprintf(stderr, "tree: Error in gethostname, using \"localhost\" as a hostname.\n");
+      hyperlinkHostname = strdup("localhost");
+    }
+    else {
+      hyperlinkHostname = strdup(hostname);
+    }
+    osc8_enabled=TRUE;
+  }
+}

--- a/tree.c
+++ b/tree.c
@@ -30,6 +30,7 @@ bool qflag, Nflag, Qflag, Dflag, inodeflag, devflag, hflag, Rflag;
 bool Hflag, siflag, cflag, Xflag, Jflag, duflag, pruneflag;
 bool noindent, force_color, nocolor, xdev, noreport, nolinks;
 bool ignorecase, matchdirs, fromfile, metafirst, gitignore, showinfo;
+bool hyperlinkflag;
 bool reverse, fflinks;
 int flimit;
 
@@ -135,7 +136,7 @@ int main(int argc, char **argv)
   Dflag = qflag = Nflag = Qflag = Rflag = hflag = Hflag = siflag = cflag = FALSE;
   noindent = force_color = nocolor = xdev = noreport = nolinks = reverse = FALSE;
   ignorecase = matchdirs = inodeflag = devflag = Xflag = Jflag = fflinks = FALSE;
-  duflag = pruneflag = metafirst = gitignore = FALSE;
+  duflag = pruneflag = metafirst = gitignore = hyperlinkflag = FALSE;
 
   flimit = 0;
   dirs = xmalloc(sizeof(int) * (maxdirs=PATH_MAX));
@@ -370,6 +371,11 @@ int main(int argc, char **argv)
 	      usage(2);
 	      exit(0);
 	    }
+	    if (!strcmp("--hyperlink", argv[i])) {
+	      j = strlen(argv[i])-1;
+	      hyperlinkflag = TRUE;
+	      break;
+	    }
 	    if (!strcmp("--version",argv[i])) {
 	      j = strlen(argv[i])-1;
 	      showversion = TRUE;
@@ -545,6 +551,7 @@ int main(int argc, char **argv)
 
   setoutput(outfilename);
 
+  osc8_setup();
   parse_dir_colors();
   initlinedraw(0);
   
@@ -622,11 +629,11 @@ void usage(int n)
 	"usage: tree [-acdfghilnpqrstuvxACDFJQNSUX] [-L level [-R]] [-H  baseHREF]\n"
 	"\t[-T title] [-o filename] [-P pattern] [-I pattern] [--gitignore]\n"
 	"\t[--gitfile[=]file] [--matchdirs] [--metafirst] [--ignore-case]\n"
-	"\t[--nolinks] [--hintro[=]file] [--houtro[=]file] [--inodes] [--device]\n"
-	"\t[--sort[=]<name>] [--dirsfirst] [--filesfirst] [--filelimit #] [--si]\n"
-	"\t[--du] [--prune] [--charset[=]X] [--timefmt[=]format] [--fromfile]\n"
-	"\t[--fromtabfile] [--fflinks] [--info] [--infofile[=]file] [--noreport]\n"
-	"\t[--version] [--help] [--] [directory ...]\n");
+	"\t[--nolinks] [--hyperlink] [--hintro[=]file] [--houtro[=]file]\n"
+	"\t[--inodes] [--device] [--sort[=]<name>] [--dirsfirst] [--filesfirst]\n"
+	"\t[--filelimit #] [--si] [--du] [--prune] [--charset[=]X] [--timefmt[=]format]"
+	"\t[--fromfile] [--fromtabfile] [--fflinks] [--info] [--infofile[=]file]\n"
+	"\t[--noreport] [--version] [--help] [--] [directory ...]\n");
 
   if (n < 2) return;
   fprintf(stdout,
@@ -683,6 +690,7 @@ void usage(int n)
 	"  -S            Print with CP437 (console) graphics indentation lines.\n"
 	"  -n            Turn colorization off always (-C overrides).\n"
 	"  -C            Turn colorization on always.\n"
+	" --hyperlink    Turn OSC8 hyperlinks on.\n"
 	"  ------- XML/HTML/JSON options -------\n"
 	"  -X            Prints out an XML representation of the tree.\n"
 	"  -J            Prints out an JSON representation of the tree.\n"

--- a/tree.h
+++ b/tree.h
@@ -306,6 +306,10 @@ void printcomment(int line, int lines, char *s);
 /* list.c */
 void new_emit_unix(char **dirname, bool needfulltree);
 
+/* osc8.c */
+int print_osc8(const char* dirname, char* filename);
+void osc8_setup();
+void endosc8();
 
 /* We use the strverscmp.c file if we're not linux: */
 #ifndef __linux__

--- a/unix.c
+++ b/unix.c
@@ -18,10 +18,11 @@
 #include "tree.h"
 
 extern FILE *outfile;
-extern bool dflag, Fflag, duflag, metafirst, hflag, siflag, noindent;
+extern bool dflag, Fflag, duflag, metafirst, hflag, siflag, noindent, hyperlinkflag;
 extern bool colorize, linktargetcolor;
 extern const struct linedraw *linedraw;
 extern int *dirs;
+extern bool osc8_enabled;
 
 static char info[512] = {0};
 
@@ -42,6 +43,9 @@ int unix_printfile(char *dirname, char *filename, struct _info *file, int descen
 {
   int colored = FALSE, c;
 
+  if (osc8_enabled)
+    print_osc8(dirname, filename);
+
   if (file && colorize) {
     if (file->lnk && linktargetcolor) colored = color(file->lnkmode,file->name,file->orphan,FALSE);
     else colored = color(file->mode,file->name,file->orphan,FALSE);
@@ -50,6 +54,7 @@ int unix_printfile(char *dirname, char *filename, struct _info *file, int descen
   printit(filename);
 
   if (colored) endcolor();
+  if (osc8_enabled) endosc8();
 
   if (file) {
     if (Fflag && !file->lnk) {


### PR DESCRIPTION
In something like tree where sometimes the list can be very long and getting the path of a file out of the tree output is not necessarily trivial, having terminal hyperlink is really nice !

I have used a variation of this PR for a few month now without any issues (but I reworked it a bit before making the PR so a bug could have sneaked in there).

Some info on terminal hyperlinks (OSC 8 escape sequence)
https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
https://github.com/Alhadis/OSC8-Adoption