### PR TITLE
Check file is not null before trying to get it's name in unix_printfile

### DIFF
--- a/unix.c
+++ b/unix.c
@@ -66,7 +66,7 @@ int unix_printfile(char *dirname, char *filename, struct _info *file, int descen
   bool colored = false;
   int c;
 
-  if (hyperflag) open_hyperlink(dirname, file->name);
+  if (file && hyperflag) open_hyperlink(dirname, file->name);
 
   if (file && colorize) {
     if (file->lnk && linktargetcolor) colored = color(file->lnkmode, file->name, file->orphan, false);


### PR DESCRIPTION
This caused a segfault if you tried `tree --hyperlink non_existant_folder`