### PR TITLE
chore: add codespell support (config, workflow to detect/not fix) and make it fix some typos

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git*,.codespellrc
+check-hidden = true
+ignore-regex = \bMattern\b
+ignore-words-list = sav

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,25 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Annotate locations with typos
+        uses: codespell-project/codespell-problem-matcher@v1
+      - name: Codespell
+        uses: codespell-project/actions-codespell@v2

--- a/CHANGES
+++ b/CHANGES
@@ -264,7 +264,7 @@ Version 2.0.0 (12/21/2021)
 
 Version 1.8.0 (11/16/2018)
   - Added an experimental --fromfile option (suggested by several people.)
-    This may eventually be replaced or supplimented by a --fromjson option.
+    This may eventually be replaced or supplemented by a --fromjson option.
   - Added support for BSD's CLICOLOR and CLICOLOR_FORCE environment variables.
     (Suggested by Alyssa Ross)
   - Use strftime() exclusively when formatting date/time to respect locale.
@@ -382,7 +382,7 @@ Version 1.5.2 (06/06/08)
 
 Version 1.5.1.2 (06/04/08)
   - Fixed compile issues related to MB_CUR_MAX on non-linux machines.
-  - Removed unecessary features.h
+  - Removed unnecessary features.h
 
 Version 1.5.1.1 (06/11/07)
   - Regression in HTML output, fixed formatting issues.


### PR DESCRIPTION
More about codespell: https://github.com/codespell-project/codespell .

I personally introduced it to dozens if not hundreds of projects already and so far only positive feedback.

CI workflow has 'permissions' set only to 'read' so also should be safe.

It is just only few typos in CHANGES so feel free to ignore/close, keep in mind for future ;-)