### PR TITLE
Add --focus-root feature for focused tree views

### DIFF
--- a/tree.h
+++ b/tree.h
@@ -191,6 +191,7 @@ int patignore(const char *name, bool isdir);
 int patinclude(const char *name, bool isdir);
 struct _info **unix_getfulltree(char *d, u_long lev, dev_t dev, off_t *size, char **err);
 struct _info **read_dir(char *dir, ssize_t *n, int infotop);
+int is_on_focus_path(const char *dirname, const char *name);
 
 int filesfirst(struct _info **, struct _info **);
 int dirsfirst(struct _info **, struct _info **);


### PR DESCRIPTION
Adds the ability to show a "focused" view of the tree, where specific deep path(s) are fully expanded while sibling directories/files are collapsed with optional summary counts.

New options:
```
  --focus-root X    Show tree from X, treating directory arguments as
                    focus paths. Collapses siblings not on focus paths.
  --no-focus-counts Hide counts in collapsed summaries (show just "...")
  --focus-collapse X  Collapse mode controlling what gets collapsed:
                    - none (default): Named folder collapse, show files
                    - files: Named folder collapse, collapse files too
                    - folders: Anonymous collapse for dirs, show files
                    - all: Anonymous collapse for everything
  --focus-collapse-limit #  Show first # consecutive collapsed items
                    individually, then switch to anonymous summary

```
Example:

```
  tree --focus-root . --focus-collapse-limit 5 path/to/target
```

This shows the tree from current directory, fully expanding path/to/target, while showing first 5 sibling directories with named collapse format (dirname/... (N subdirs, M files)) then collapsing the rest into a summary.

- Fixes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)

More specific example which motivated my issue/PR here:

<details>
<summary>edited -- version 1: rewritten, as to collapse those listed after if more than a limit</summary> 

```shell
❯ tree --dirsfirst --focus-collapse-limit 5 --focus-root . athl=yhalchenko/ses=20231001T190446/photos | sed -e's, ->.*,,g'
.
├── assets/... (3 subdirectories, 1 file)
├── athl=yhalchenko
│   ├── ses=20230613T113607/... (3 files)
│   ├── ses=20231001T190446
│   │   ├── photos
│   │   │   ├── 20231001T172351.jpg
│   │   │   ├── 20231001T174305.jpg
│   │   │   └── 20231001T181415.jpg
│   │   ├── info.json
│   │   ├── tracking.json
│   │   └── tracking.parquet
│   ├── ses=20231004T000116/... (3 files)
│   ├── ses=20231006T144105/... (3 files)
│   ├── ses=20231008T215113/... (3 files)
│   ├── ses=20231011T102153/... (1 subdirectory, 3 files)
│   ├── ses=20231012T102112/... (1 subdirectory, 3 files)
│   ├── ... (293 directories)
│   ├── athlete.json
│   ├── avatar.jpg
│   ├── gear.json
│   ├── sessions.tsv
│   ├── sync_state.json
│   └── timezone-history.tsv
├── code/... (1 file)
├── logs/... (36 files)
├── athletes.tsv
├── favicon.svg
├── index.html
├── Makefile
└── README.md

306 directories, 17 files
```

</details>

```shell
❯ tree --dirsfirst --focus-collapse-limit 5 --focus-root . athl=yhalchenko/ses=20231001T190446/photos | sed -e's, ->.*,,g'
.
├── assets/... (3 subdirectories, 1 file)
├── athl=yhalchenko
│   ├── ses=20230613T113607/... (3 files)
│   ├── ses=20231001T190446
│   │   ├── photos
│   │   │   ├── 20231001T172351.jpg
│   │   │   ├── 20231001T174305.jpg
│   │   │   └── 20231001T181415.jpg
│   │   ├── info.json
│   │   ├── tracking.json
│   │   └── tracking.parquet
│   ├── ... (298 directories)
│   ├── athlete.json
│   ├── avatar.jpg
│   ├── gear.json
│   ├── sessions.tsv
│   ├── sync_state.json
│   └── timezone-history.tsv
├── code/... (1 file)
├── logs/... (36 files)
├── athletes.tsv
├── favicon.svg
├── index.html
├── Makefile
└── README.md

306 directories, 17 files
```

NB note that I am also looking for some option to handle those symlinks -- I do not care to list entire deref path.

The goal here -- given a collection of prototypical paths to be able to demonstrate overall structure of the filetree.  Will be really handy to review structured filetree hierarchies like we have in https://bids.neuroimaging.io/ .