### PR TITLE
fix discards 'const' qualifier from pointer target type

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -774,7 +774,7 @@ void usage(int n)
 int patignore(const char *name, bool isdir, bool checkpaths)
 {
   int i;
-  char *pc;
+  const char *pc;
   for(i=0; i < ipattern; i++) {
     if (patmatch(name, ipatterns[i], isdir)) return 1;
     else if (checkpaths) {
@@ -794,7 +794,7 @@ int patignore(const char *name, bool isdir, bool checkpaths)
 int patinclude(const char *name, bool isdir, bool checkpaths)
 {
   int i;
-  char *pc;
+  const char *pc;
   for(i=0; i < pattern; i++) {
     if (patmatch(name, patterns[i], isdir)) return 1;
     else if (checkpaths) {


### PR DESCRIPTION
Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

Fixes:
tree.c: In function 'patignore':
tree.c:781:10: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  781 |       pc = strchr(name, file_pathsep[0]);
      |          ^
tree.c: In function 'patinclude':
tree.c:801:10: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
  801 |       pc = strchr(name, file_pathsep[0]);
      |          ^