### PR TITLE
fix discards 'const' qualifier from pointer target type

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -1247,7 +1247,7 @@ static char cond_lower(char c)
  *    0 on a mismatch
  *   -1 on a syntax error in the pattern
  */
-int patmatch(const char *buf, const char *pat, bool isdir)
+int patmatch(const char *buf, char *pat, bool isdir)
 {
   int match = 1, n;
   char *bar = strchr(pat, '|');

--- a/tree.h
+++ b/tree.h
@@ -277,7 +277,7 @@ int ctimesort(struct _info **, struct _info **);
 int sizecmp(off_t a, off_t b);
 int fsizesort(struct _info **a, struct _info **b);
 
-int patmatch(const char *buf, const char *pat, bool isdir);
+int patmatch(const char *buf, char *pat, bool isdir);
 void indent(int maxlevel);
 void free_dir(struct _info **);
 #ifdef __EMX__


### PR DESCRIPTION
- fixes remaking #32 issue.


As pat is modified in patmatch, declare it as char * (not const char *)

Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the input argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html