### PR TITLE
Add --stats flag displaying hidden files, size, newest/oldest file

### DIFF
--- a/list.c
+++ b/list.c
@@ -96,7 +96,7 @@ void emit_tree(char **dirname, bool needfulltree)
     lc.printinfo(dirname[i], info, 0);
 
     needsclosed = lc.printfile(dirname[i], dirname[i], info, (dir != NULL) || (!dir && n));
-    subtotal = (struct totals){0, 0, 0};
+    subtotal = (struct totals){0};
 
     if (!dir && n) {
       lc.error("error opening dir");
@@ -123,15 +123,43 @@ void emit_tree(char **dirname, bool needfulltree)
 
     tot.files += subtotal.files;
     tot.dirs += subtotal.dirs;
+    tot.hidden += subtotal.hidden;
+    if (subtotal.newest_time > tot.newest_time) {
+      tot.newest_time = subtotal.newest_time;
+      strncpy(tot.newest_name, subtotal.newest_name, 255);
+    }
+    if (tot.oldest_time == 0 || (subtotal.oldest_time && subtotal.oldest_time < tot.oldest_time)) {
+      tot.oldest_time = subtotal.oldest_time;
+      strncpy(tot.oldest_name, subtotal.oldest_name, 255);
+    }
     // Do not bother to accumulate tot.size in listdir.
     // This is already done in getfulltree()
-    if (flag.du) tot.size += info? info->size : 0;
+    if (flag.du || flag.statsflag) tot.size += info? info->size : 0;
 
     if (ig != NULL) ig = flush_filterstack();
     if (inf != NULL) inf = pop_infostack();
   }
 
   if (!flag.noreport) lc.report(tot);
+  if (flag.statsflag) {
+    char newest[32], oldest[32];
+    struct tm *tm;
+    fprintf(outfile, "\n--- Stats ---\n");
+    fprintf(outfile, "Directories : %zu\n", tot.dirs);
+    fprintf(outfile, "Files       : %zu\n", tot.files);
+    fprintf(outfile, "Hidden      : %zu\n", tot.hidden);
+    fprintf(outfile, "Total size  : %lld bytes\n", (long long)tot.size);
+    if (tot.newest_time) {
+      tm = localtime(&tot.newest_time);
+      strftime(newest, sizeof(newest), "%Y-%m-%d", tm);
+      fprintf(outfile, "Newest file : %s (%s)\n", tot.newest_name, newest);
+    }
+    if (tot.oldest_time) {
+      tm = localtime(&tot.oldest_time);
+      strftime(oldest, sizeof(oldest), "%Y-%m-%d", tm);
+      fprintf(outfile, "Oldest file : %s (%s)\n", tot.oldest_name, oldest);
+    }
+  }
 
   lc.outtro();
 }
@@ -253,7 +281,19 @@ struct totals listdir(char *dirname, struct _info **dir, int lev, dev_t dev, boo
 	  if (subdir == NULL) descend = 0;
 	}
       }
-    } else tot.files++;
+    } else {
+      tot.files++;
+      if ((*dir)->size) tot.size += (*dir)->size;
+      if ((*dir)->name[0] == '.') tot.hidden++;
+      if (tot.newest_time == 0 || (*dir)->mtime > tot.newest_time) {
+        tot.newest_time = (*dir)->mtime;
+        strncpy(tot.newest_name, (*dir)->name, 255);
+      }
+      if (tot.oldest_time == 0 || (*dir)->mtime < tot.oldest_time) {
+        tot.oldest_time = (*dir)->mtime;
+        strncpy(tot.oldest_name, (*dir)->name, 255);
+      }
+    }
 
     needsclosed = lc.printfile(dirname, filename, *dir, descend + htmldescend + (flag.J && errors));
     if (err) lc.error(err);

--- a/tree.c
+++ b/tree.c
@@ -377,8 +377,14 @@ int main(int argc, char **argv)
 	      flag.noreport = (opt_toggle? !flag.noreport : true);
 	      break;
 	    }
-	    if (!strcmp("--nolinks",argv[i])) {
+	    if (!strcmp("--stats",argv[i])) {
 	      j = strlen(argv[i])-1;
+	      flag.statsflag = true;
+	      flag.du = true;
+	      break;
+	    }
+            if (!strcmp("--nolinks",argv[i])) {
+              j = strlen(argv[i])-1;
 	      flag.nolinks = (opt_toggle? !flag.nolinks : true);
 	      break;
 	    }

--- a/tree.h
+++ b/tree.h
@@ -92,7 +92,7 @@ struct Flags {
   bool a, c, d, f, g, h, l, p, q, s, u;
   bool D, F, H, J, N, Q, R, X;
   bool inode, dev, si, du, prune, hyper;
-  bool noindent, force_color, nocolor, xdev, noreport, nolinks;
+  bool noindent, force_color, nocolor, xdev, noreport, nolinks, statsflag;
   bool ignorecase, matchdirs, fromfile, metafirst, gitignore, showinfo;
   bool reverse, fflinks, htmloffset, acl, selinux, condense_singletons;
   bool colorize, ansilines, linktargetcolor, remove_space;
@@ -115,6 +115,8 @@ struct _info {
   uid_t uid;
   gid_t gid;
   off_t size;
+  time_t newest_time, oldest_time;
+  char newest_name[256], oldest_name[256];
   time_t atime, ctime, mtime;
   dev_t dev, ldev;
   ino_t inode, linode;
@@ -171,8 +173,10 @@ struct infofile {
 
 /* list.c */
 struct totals {
-  size_t files, dirs;
+  size_t files, dirs, hidden;
   off_t size;
+  time_t newest_time, oldest_time;
+  char newest_name[256], oldest_name[256];
 };
 
 struct listingcalls {


### PR DESCRIPTION
Add --stats flag

Extends tree output with a --stats summary block showing:
- Hidden file count
- Total size on disk
- Newest file with timestamp
- Oldest file with timestamp

The default report line is preserved. --stats appends additional
detail for users who want more than the basic directory/file count.