### PR TITLE
Fix absolute path matching for global --infofile option

### DIFF
--- a/info.c
+++ b/info.c
@@ -45,7 +45,7 @@ struct comment *new_comment(struct pattern *phead, char **line, int lines)
   return com;
 }
 
-struct infofile *new_infofile(const char *path, bool checkparents)
+struct infofile *new_infofile(const char *path, bool checkparents, bool is_global)
 {
   struct stat st;
   char buf[PATH_MAX], rpath[PATH_MAX];
@@ -112,7 +112,7 @@ struct infofile *new_infofile(const char *path, bool checkparents)
 
   inf = xmalloc(sizeof(struct infofile));
   inf->comments = chead;
-  inf->path = scopy(path);
+  inf->path = scopy(is_global ? "" : path);
   inf->next = NULL;
 
   return inf;

--- a/tree.c
+++ b/tree.c
@@ -485,7 +485,7 @@ int main(int argc, char **argv)
 	    }
 	    if ((arg = long_arg(argv, i, &j, &n, "--infofile")) != NULL) {
 	      flag.showinfo = true;
-	      inf = new_infofile(arg, false);
+	      inf = new_infofile(arg, false, true);
 	      if (inf != NULL) push_infostack(inf);
 	      else {
 		fprintf(stderr,"tree: Could not load infofile\n");
@@ -616,7 +616,7 @@ int main(int argc, char **argv)
 
 
   if (flag.showinfo) {
-    push_infostack(new_infofile(INFO_PATH, false));
+    push_infostack(new_infofile(INFO_PATH, false, true));
   }
 
   needfulltree = flag.du || flag.prune || flag.matchdirs || flag.fromfile || flag.condense_singletons;
@@ -1029,7 +1029,7 @@ void push_files(const char *dir, struct ignorefile **ig, struct infofile **inf, 
     if (*ig == NULL) *ig = tig;
   }
   if (flag.showinfo) {
-    push_infostack(*inf = new_infofile(dir, top));
+    push_infostack(*inf = new_infofile(dir, top, false));
   }
 }
 

--- a/tree.h
+++ b/tree.h
@@ -232,7 +232,7 @@ void html_report(struct totals tot);
 void html_encode(FILE *fd, char *s);
 
 /* info.c */
-struct infofile *new_infofile(const char *path, bool checkparents);
+struct infofile *new_infofile(const char *path, bool checkparents, bool is_global);
 void push_infostack(struct infofile *inf);
 struct infofile *pop_infostack(void);
 struct comment *infocheck(const char *path, const char *name, int top, bool isdir);


### PR DESCRIPTION
Fixes https://gitlab.com/OldManProgrammer/unix-tree/-/work_items/40

Though many entries are in doc/global_info file, only lost+found is annotated when running 
  $ tree -d -L 2 --infofile doc/global_info
  
When a global info file is loaded via `--infofile` as a regular file, `new_infofile()` incorrectly set `inf->path` to the file path (e.g., "doc/global_info") instead of an empty string. During matching, `infocheck()` prefixed the patterns with this path, leading to matching failures for absolute paths (e.g., `/home` becoming `"doc/global_info/home"` instead of `"/home"`).

This patch sets `inf->path` to an empty string when the info file is loaded globally as a regular file, allowing absolute path matching to work correctly.

Suggeted-by: Antigravity <antigravity@google.com>
Signed-off-by: Masatake YAMATO <yamato@redhat.com>
