### PR TITLE
-J: stop growing empty "contents" arrays after a read error

### DIFF
--- a/list.c
+++ b/list.c
@@ -255,7 +255,7 @@ struct totals listdir(char *dirname, struct _info **dir, int lev, dev_t dev, boo
       }
     } else tot.files++;
 
-    needsclosed = lc.printfile(dirname, filename, *dir, descend + htmldescend + (flag.J && errors));
+    needsclosed = lc.printfile(dirname, filename, *dir, (descend != 0) + htmldescend + (flag.J && err != NULL));
     if (err) lc.error(err);
 
     if (descend > 0) {


### PR DESCRIPTION
# Overview

Once any read error has occurred, every later entry in the JSON output grows an empty `"contents":[    ]` array, plain files included: printfile's descend argument mixes in the global error counter (`flag.J && errors`), which stays truthy for the rest of the run.

# Steps to reproduce

```console
$ mkdir -p j1/{sub,locked}
$ touch j1/{afile,zfile,sub/x}
$ chmod 0 j1/locked
$ tree -J j1
[
    {"type":"directory","name":"j1","contents":[
        {"type":"file","name":"afile"},
        {"type":"directory","name":"locked","contents":[{"error": "error opening dir"}    ]},
        {"type":"directory","name":"sub","contents":[
            {"type":"file","name":"x","contents":[    ]}
        ]},
        {"type":"file","name":"zfile","contents":[    ]}
    ]}
,    {"type":"report","directories":3,"files":3}
]
```

# After this change

```console
$ mkdir -p j1/{sub,locked}
$ touch j1/{afile,zfile,sub/x}
$ chmod 0 j1/locked
$ tree -J j1
[
    {"type":"directory","name":"j1","contents":[
        {"type":"file","name":"afile"},
        {"type":"directory","name":"locked","contents":[{"error": "error opening dir"}    ]},
        {"type":"directory","name":"sub","contents":[
            {"type":"file","name":"x"}
        ]},
        {"type":"file","name":"zfile"}
    ]}
,    {"type":"report","directories":3,"files":3}
]
```
