### PR TITLE
-J: emit the separating comma after an empty root

### DIFF
--- a/list.c
+++ b/list.c
@@ -109,7 +109,7 @@ void emit_tree(char **dirname, bool needfulltree)
       lc.newline(info, 0, 0, dirname[i+1] != NULL);
       subtotal.dirs++;
     } else {
-      lc.newline(info, 0, 0, 0);
+      lc.newline(info, 0, 0, needsclosed? 0 : (dirname[i+1] != NULL));
       if (dir) {
 	subtotal = listdir(dirname[i], dir, 1, st.st_dev, needfulltree);
 	subtotal.dirs++;


### PR DESCRIPTION
# Overview

With multiple root arguments, an empty root opens no contents array, so close() — which emits the comma between root objects — is never called for it, and nothing else prints the comma either: the output is invalid JSON.

# Steps to reproduce

```console
$ mkdir -p empty sub
$ touch sub/x
$ tree -J empty sub
[
    {"type":"directory","name":"empty"}
    {"type":"directory","name":"sub","contents":[
        {"type":"file","name":"x"}
    ]}
,    {"type":"report","directories":1,"files":1}
]
```

# After this change

```console
$ mkdir -p empty sub
$ touch sub/x
$ tree -J empty sub
[
    {"type":"directory","name":"empty"},
    {"type":"directory","name":"sub","contents":[
        {"type":"file","name":"x"}
    ]}
,    {"type":"report","directories":1,"files":1}
]
```