### PR TITLE
-J: drop the trailing comma inside an unopenable root's contents

### DIFF
--- a/list.c
+++ b/list.c
@@ -100,13 +100,13 @@ void emit_tree(char **dirname, bool needfulltree)
 
     if (!dir && n) {
       lc.error("error opening dir");
-      lc.newline(info, 0, 0, dirname[i+1] != NULL);
+      lc.newline(info, 0, 0, 0);
       if (!info) errors++;
       else subtotal.files++;
     } else if (flag.flimit > 0 && n > flag.flimit) {
       sprintf(errbuf,"%ld entries exceeds filelimit, not opening dir", n);
       lc.error(errbuf);
-      lc.newline(info, 0, 0, dirname[i+1] != NULL);
+      lc.newline(info, 0, 0, 0);
       subtotal.dirs++;
     } else {
       lc.newline(info, 0, 0, 0);


### PR DESCRIPTION
# Overview

With -J, when a root that cannot be opened (a plain file, an unreadable directory, or one over --filelimit) is followed by another root, a stray comma is left inside its contents array: `"contents":[{"error": "..."},]` — invalid JSON. The separating comma between roots is printed twice, and the first copy lands inside the array.

# Steps to reproduce

```console
$ mkdir -p sub
$ touch sub/x f
$ tree -J f sub
[
    {"type":"file","name":"f","contents":[{"error": "error opening dir"},
    ]},
    {"type":"directory","name":"sub","contents":[
        {"type":"file","name":"x"}
    ]}
,    {"type":"report","directories":1,"files":2}
]
```

# After this change

```console
$ mkdir -p sub
$ touch sub/x f
$ tree -J f sub
[
    {"type":"file","name":"f","contents":[{"error": "error opening dir"}
    ]},
    {"type":"directory","name":"sub","contents":[
        {"type":"file","name":"x"}
    ]}
,    {"type":"report","directories":1,"files":2}
]
```