### PR TITLE
Do not treat a glob syntax error as a match in -P/-I

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -776,11 +776,11 @@ int patignore(const char *name, bool isdir, bool checkpaths)
   int i;
   const char *pc;
   for(i=0; i < ipattern; i++) {
-    if (patmatch(name, ipatterns[i], isdir)) return 1;
+    if (patmatch(name, ipatterns[i], isdir) == 1) return 1;
     else if (checkpaths) {
       pc = strchr(name, file_pathsep[0]);
       while (pc != NULL && *pc != '\0') {
-        if (patmatch(pc+1, ipatterns[i], isdir)) return 1;
+        if (patmatch(pc+1, ipatterns[i], isdir) == 1) return 1;
         pc = strchr(pc+1, file_pathsep[0]);
       }
     }
@@ -796,11 +796,11 @@ int patinclude(const char *name, bool isdir, bool checkpaths)
   int i;
   const char *pc;
   for(i=0; i < pattern; i++) {
-    if (patmatch(name, patterns[i], isdir)) return 1;
+    if (patmatch(name, patterns[i], isdir) == 1) return 1;
     else if (checkpaths) {
       pc = strchr(name, file_pathsep[0]);
       while (pc != NULL && *pc != '\0') {
-        if (patmatch(pc+1, patterns[i], isdir)) return 1;
+        if (patmatch(pc+1, patterns[i], isdir) == 1) return 1;
         pc = strchr(pc+1, file_pathsep[0]);
       }
     }


### PR DESCRIPTION
# Overview

patmatch() documents three return values: 1 match, 0 mismatch, -1 syntax error. patignore() and patinclude() only test the result for truth, so -1 counts as a match and a malformed pattern matches every file: -P lists everything as if it were absent, -I hides the whole tree. With this change a syntax error behaves like a pattern that matches nothing. Erroring out on a bad pattern would also be defensible — happy to rework in that direction if preferred.

# Steps to reproduce

```console
$ mkdir pat
$ touch pat/{aa,bb}
$ tree -P '[' pat
pat
├── aa
└── bb

1 directory, 2 files
$ tree -I '[' pat
pat

0 directories, 0 files
```

# After this change

```console
$ mkdir pat
$ touch pat/{aa,bb}
$ tree -P '[' pat
pat

0 directories, 0 files
$ tree -I '[' pat
pat
├── aa
└── bb

1 directory, 2 files
```