### PR TITLE
Count read errors in the full-tree walk so the exit status is 2

### DIFF
--- a/tree.c
+++ b/tree.c
@@ -1069,6 +1069,7 @@ struct _info **unix_getfulltree(char *d, u_long lev, dev_t dev, off_t *size, cha
 
   if (dir == NULL && n) {
     *err = scopy("error opening dir");
+    if (lev > 0) errors++;
     if (tmp_pattern) pattern = tmp_pattern;
     return NULL;
   }
@@ -1082,6 +1083,7 @@ struct _info **unix_getfulltree(char *d, u_long lev, dev_t dev, off_t *size, cha
   if (flag.flimit > 0 && n > flag.flimit) {
     sprintf(path,"%ld entries exceeds filelimit, not opening dir",n);
     *err = scopy(path);
+    if (lev > 0) errors++;
     free_dir(sav);
     free(path);
     if (tmp_pattern) pattern = tmp_pattern;


### PR DESCRIPTION
# Overview

tree exits 2 when a directory could not be read, but only the read_dir() path in listdir() counts such errors. The options that pre-build the whole tree (--du, --prune, --matchdirs, --fromfile) discover the same failures in unix_getfulltree(), which records the error string for display but never increments the counter — with --prune the unreadable directory is even pruned from the output, so the exit status was the only trace of the failure. "recursive, not followed" is not counted, and an unreadable root argument keeps exiting 0 in both walk modes, matching the existing behavior of the read_dir() path.

# Steps to reproduce

```console
$ mkdir -p j1/{sub,locked}
$ touch j1/{afile,sub/x}
$ chmod 0 j1/locked
$ tree j1 > /dev/null; echo $?
2
$ tree --du j1 > /dev/null; echo $?
0
$ tree --prune j1 > /dev/null; echo $?
0
```

# After this change

```console
$ mkdir -p j1/{sub,locked}
$ touch j1/{afile,sub/x}
$ chmod 0 j1/locked
$ tree --du j1 > /dev/null; echo $?
2
$ tree --prune j1 > /dev/null; echo $?
2
```