### PR TITLE
Reset the indent state for -R sub-listings

### DIFF
--- a/list.c
+++ b/list.c
@@ -218,6 +218,7 @@ struct totals listdir(char *dirname, struct _info **dir, int lev, dev_t dev, boo
 	    int *dirsave = xmalloc(sizeof(int) * (size_t)(lev + 2));
 
 	    memcpy(dirsave, dirs, sizeof(int) * (size_t)(lev+1));
+	    memset(dirs, 0, sizeof(int) * (size_t)(lev+1));
 	    sprintf(output, "%s/00Tree.html", newpath);
 	    setoutput(output);
 	    emit_tree(paths, hasfulltree);


### PR DESCRIPTION
# Overview

With -R, tree writes a sub-listing (00Tree.html) into each directory at the -L limit by calling emit_tree() recursively. The indent state lives in the global array dirs[], and indent() picks the glyph for level i by checking dirs[i+1]: nonzero means "a deeper level is still open", so it prints a continuation line instead of a branch. The recursive call inherits the outer walk's leftover dirs[] entries, so at the sub-listing's deepest level every branch prints as a continuation line. This change clears dirs[] before the nested emit_tree() — it is already saved and restored around it — so the sub-listing starts from the same state as a top-level run. The outer listing (top.html) is byte-identical before and after.

# Steps to reproduce

```console
$ mkdir -p r/a/{b/c,tail}
$ touch r/a/{b/f1,b/c/deep,tail/f2}
$ cd r && tree -L 2 -R -o top.html .
$ cat a/b/00Tree.html
./a/b
│   00Tree.html
│   c
│   └── deep
└── f1

2 directories, 3 files
```

# After this change

```console
$ mkdir -p r/a/{b/c,tail}
$ touch r/a/{b/f1,b/c/deep,tail/f2}
$ cd r && tree -L 2 -R -o top.html .
$ cat a/b/00Tree.html
./a/b
├── 00Tree.html
├── c
│   └── deep
└── f1

2 directories, 3 files
```