### PR TITLE
fprune: skip a --fromfile entry that overflows the path buffer

### DIFF
--- a/file.c
+++ b/file.c
@@ -110,21 +110,33 @@ struct _info **fprune(struct _info *head, const char *path, bool matched, bool r
   struct ignorefile *ig = NULL;
   struct infofile *inf = NULL;
   char *cur, *fpath = xmalloc(sizeof(char) * MAXPATH);
-  size_t i, count = 0;
-  bool show, defmatched = matched;
+  size_t i, count = 0, baselen;
+  bool show, defmatched = matched, fits;
   int tmp_pattern = 0;
 
+  if (strlen(path) >= MAXPATH) {
+    free(fpath);
+    return NULL;
+  }
   strcpy(fpath, path);
   cur = fpath + strlen(fpath);
   *(cur++) = '/';
+  baselen = (size_t)(cur - fpath);
 
   push_files(path, &ig, &inf, root);
 
   for(ent = head; ent != NULL;) {
-    strcpy(cur, ent->name);
-    if (ent->tchild) ent->isdir = 1;
+    /* An entry name this long can only come from a crafted --fromfile
+       input, since real filesystem paths are bounded well under MAXPATH;
+       skip it instead of overflowing fpath's fixed-size buffer. */
+    fits = baselen + strlen(ent->name) < MAXPATH;
+    if (fits) {
+      strcpy(cur, ent->name);
+      if (ent->tchild) ent->isdir = 1;
+    }
 
-    show = true;
+    show = fits;
+    if (!fits) goto next_ent;
     if (flag.d && !ent->isdir) show = false;
     if (!flag.a && ent->name[0] == '.') show = false;
     if (show && !matched) {
@@ -174,6 +186,7 @@ struct _info **fprune(struct _info *head, const char *path, bool matched, bool r
     }
     matched = defmatched;
 
+next_ent:
     t = ent;
     ent = ent->next;
     if (show) {


### PR DESCRIPTION
Fixes #45.

fprune() builds each entry's full path in a fixed MAXPATH buffer by appending the entry name after the parent directory prefix, but never checked whether the name actually fit. A --fromfile input line with a path component around 65535 bytes long overruns the buffer by one byte, since fpath is sized to hold exactly the prefix plus a name that long, with nothing left over for the trailing NUL.

On a real filesystem this can't happen, since actual path components are bounded well below MAXPATH, but --fromfile builds the tree from arbitrary text lines instead, so nothing stops a crafted or corrupted input file from supplying an oversized name.

Added the same kind of check to the initial path copy at the top of the function, since a --fromfile-supplied root path could hit the same problem, then skip any single entry whose name would overflow the buffer instead of writing into it, marking it as not shown so it just gets dropped from the tree rather than corrupting memory.

Verified with an ASan build using the issue's exact reproducer (a 65535-byte line via --fromfile): crashes with a heap-buffer-overflow write on unpatched master, exits cleanly with this change. Normal --fromfile usage with regular-length paths still builds the tree correctly, checked by hand since this repo doesn't have an automated test suite.